### PR TITLE
Add ES2022 target & GitHub workflow to execute the bench.sh file

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,23 @@
+on:
+  ## Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+
+jobs:
+  bench:
+    name: Run benchmarks
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: development
+    strategy:
+      matrix:
+        node: [ '14', '16', 'lts/*' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Use Node.js ${{ matrix.node }}'
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - name: Run bench
+        run: ./bench.sh

--- a/bench.sh
+++ b/bench.sh
@@ -32,6 +32,13 @@ node loop.es2018.js
 
 echo "------------------------------------------------------"
 
+echo "benchmarking async/await with TS target es2022"
+npx tsc --target es2022 loop.ts --outfile loop.es2022.js
+node loop.es2022.js
+
+
+echo "------------------------------------------------------"
+
 echo "benchmarking async/await with TS target esnext"
 npx tsc --target esnext loop.ts --outfile loop.esnext.js
 node loop.esnext.js


### PR DESCRIPTION
now you can run the benchmarks without leaving GitHub :fire: You can trigger the workflow via GitHub's CLI or at the _Actions_ page.

![image](https://user-images.githubusercontent.com/13461315/158277400-c6937845-fd15-4991-82a4-d77e265ae4ae.png)

Also, I've added the `ES2022` target just because why not 
